### PR TITLE
Refactor/jkw/restructure store

### DIFF
--- a/src/API.js
+++ b/src/API.js
@@ -3,9 +3,9 @@ const key = "api-key=x5EmADYf2iLxSpp6H6EiN4JnZCZ5RMps";
 
 export const fetchBooks = (listName) => {
   return fetch(`${rootUrl}lists/current/${listName}.json?${key}`)
-    .then(response => {
-      if (response.ok) {
-        return response.json()
-      }
-    })
+  .then(response => {
+    if (response.ok) {
+      return response.json()
+    }
+  })
 }

--- a/src/API.js
+++ b/src/API.js
@@ -1,8 +1,8 @@
 const rootUrl = "https://api.nytimes.com/svc/books/v3/";
 const key = "api-key=x5EmADYf2iLxSpp6H6EiN4JnZCZ5RMps";
 
-export const fetchAllBooks = () => {
-  return fetch(`${rootUrl}lists/current/hardcover-fiction.json?${key}`)
+export const fetchBooks = (listName) => {
+  return fetch(`${rootUrl}lists/current/${listName}.json?${key}`)
     .then(response => {
       if (response.ok) {
         return response.json()

--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -2,30 +2,62 @@ import React, { Component } from 'react'
 import './App.css';
 import Books from '../Books/Books'
 import Nav from '../Nav/Nav'
+import { fetchBooks } from '../../API';
+import { connect } from 'react-redux'
+import { setBooks, setList } from '../../actions';
+import { bindActionCreators } from 'redux';
 
 class App extends Component {
   constructor() {
     super();
     this.state = {
       lists: {
-        'hardcover-fiction': true,
         'celebrities': true,
-        'food-and-fitness': true
+        'food-and-fitness': true,
+        'hardcover-fiction': true,
+        'games-and-activities': true,
+        'health': true,
       }
     }
   }
 
+  componentDidMount() {
+    const { setBooks, setList } = this.props
+    const allListUrls = Object.keys(this.state.lists)
+    try {
+      allListUrls.map(async url => {
+        const response = await fetchBooks(url);
+        setBooks(response.results.books);
+        const books = response.results.books;
+        console.log('books after setBooks', books)
+        return setList(url, books.map(book => book.primary_isbn10));
+      })
+    }
+    catch ({ message }) {
+      alert(message)
+    }
+  }
+
+  filterBooks = (listName) => {
+    const listOfIds = this.props.lists[listName]
+    const filteredBooks = this.props.books.filter(book => listOfIds.includes(book.primary_isbn10))
+    console.log('filtered books from filterBooks', filteredBooks)
+    return filteredBooks;
+  }
+
   createBookLists = () => {
-    const lists = this.state.lists;
-    const listsKeys = Object.keys(lists);
-    const allBooks = listsKeys.map(list => {
-      if(lists[list]) {
+    const listUrls = this.props.lists;
+    const listsKeys = Object.keys(listUrls);
+    const listBooks = listsKeys.map(listName => {
+      const filteredBooks = this.filterBooks(listName)
+      console.log('filtered books from createBookLists', filteredBooks)
+      if(filteredBooks.length > 0) {
         return (
-          <Books key={list} id={list} list={list} />
+          <Books key={listName} id={listName} listName={listName} filteredBooks={filteredBooks}/>
         )
       }
     })
-    return allBooks
+    return listBooks
   }
 
   render() {
@@ -38,5 +70,17 @@ class App extends Component {
   }
 }
 
-export default App;
+export const mapStateToProps = ({ books, lists }) => ({
+  books,
+  lists
+})
+
+export const mapDispatchToProps = dispatch => (
+  bindActionCreators({
+    setBooks,
+    setList
+  }, dispatch)
+)
+
+export default connect(mapStateToProps, mapDispatchToProps)(App);
  

--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -9,7 +9,8 @@ class App extends Component {
     this.state = {
       lists: {
         'hardcover-fiction': true,
-        'celebrities': true
+        'celebrities': true,
+        'food-and-fitness': true
       }
     }
   }

--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -3,13 +3,39 @@ import './App.css';
 import Books from '../Books/Books'
 import Nav from '../Nav/Nav'
 
-function App () {
-  return (
-    <div className="App">
-      <Nav />
-      <Books />
-    </div>
-  );
+class App extends Component {
+  constructor() {
+    super();
+    this.state = {
+      lists: {
+        'hardcover-fiction': true
+      }
+    }
+  }
+
+  createBookLists = () => {
+    const lists = this.state.lists;
+    const listsKeys = Object.keys(lists);
+    const allBooks = listsKeys.map(list => {
+      if(lists[list]) {
+        return (
+          <Books key={list} id={list} list={list} />
+        )
+      }
+    })
+    return allBooks
+  }
+
+  render() {
+    const allBooks = this.createBookLists()
+    console.log(allBooks)
+    return (
+      <div className="App">
+        <Nav />
+        {allBooks}
+      </div>
+    );
+  }
 }
 
 export default App;

--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -8,7 +8,8 @@ class App extends Component {
     super();
     this.state = {
       lists: {
-        'hardcover-fiction': true
+        'hardcover-fiction': true,
+        'celebrities': true
       }
     }
   }
@@ -27,12 +28,10 @@ class App extends Component {
   }
 
   render() {
-    const allBooks = this.createBookLists()
-    console.log(allBooks)
     return (
       <div className="App">
         <Nav />
-        {allBooks}
+        {this.createBookLists()}
       </div>
     );
   }

--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -79,34 +79,35 @@ class App extends Component {
     return (
       <div className="App">
           <Nav />
-          <Route exact path={'/'} render={() => {
-            return (<>
-              <h1>Books!</h1>
-              <Search searchBooks={this.searchBooks}/>
-              <section className="found-book-cards" alt="found-book-cards">
-                { this.state.foundBooks ? 
-                  this.state.foundBooks.map(foundBook => {
-                    return (
-                      <>
-                        <h1>{foundBook.title}</h1><h3>{foundBook.author}</h3><h3>Ranking: {foundBook.rank}</h3><img className="Book-card-image" alt="Book cover" src={foundBook.book_image} /> 
-                      </>
-                    )
-                  }) : 
-                  <h1>Search For Book by Title or Author</h1>
-                }
-              </section>
-              {this.createBookLists()}
-            </>)
-          }}
-          />
-          <Route exact path='/:bookId' render={({ match }) => {
-            const bookClicked = books.find((book) => book.primary_isbn10 == parseInt(match.params.bookId))
-            return <BookInfo book={bookClicked} /> }}
-          />
-          <Route exact path='/favorites' render={() =>  {
-            return <ReadingList readingList={readingList} /> 
-          }
-          } />
+          <Switch>
+            <Route exact path={'/'} render={() => {
+              return (<>
+                <h1>Books!</h1>
+                <Search searchBooks={this.searchBooks}/>
+                <section className="found-book-cards" alt="found-book-cards">
+                  { this.state.foundBooks ? 
+                    this.state.foundBooks.map(foundBook => {
+                      return (
+                        <>
+                          <h1>{foundBook.title}</h1><h3>{foundBook.author}</h3><h3>Ranking: {foundBook.rank}</h3><img className="Book-card-image" alt="Book cover" src={foundBook.book_image} /> 
+                        </>
+                      )
+                    }) : 
+                    <h1>Search For Book by Title or Author</h1>
+                  }
+                </section>
+                {this.createBookLists()}
+              </>)
+            }}
+            />
+            <Route exact path='/favorites' render={() =>  
+              <ReadingList readingList={readingList} /> 
+            } />
+            <Route exact path='/:bookId' render={({ match }) => {
+              const bookClicked = books.find((book) => book.primary_isbn10 == parseInt(match.params.bookId))
+              return <BookInfo book={bookClicked} /> }}
+            />
+          </Switch>
       </div>
     );
   }

--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -2,10 +2,14 @@ import React, { Component } from 'react'
 import './App.css';
 import Books from '../Books/Books'
 import Nav from '../Nav/Nav'
+import Search from '../Search/Search'
+import BookInfo from '../BookInfo/BookInfo'
+import ReadingList from '../ReadingList/ReadingList'
 import { fetchBooks } from '../../API';
 import { connect } from 'react-redux'
 import { setBooks, setList } from '../../actions';
 import { bindActionCreators } from 'redux';
+import { Route, Switch } from 'react-router-dom';
 
 class App extends Component {
   constructor() {
@@ -60,18 +64,57 @@ class App extends Component {
     return listBooks
   }
 
+  searchBooks = (search) => {
+    let findBooks = this.props.books.filter(book => {
+      if (book.title.includes(search) || book.author.includes(search)) {
+        this.setState({ foundBooks: [book] })
+      }
+    })
+    console.log(this.state.foundBooks)
+    return findBooks;
+  }
+
   render() {
+    const { readingList, books } = this.props
     return (
       <div className="App">
-        <Nav />
-        {this.createBookLists()}
+          <Nav />
+          <Route exact path={'/'} render={() => {
+            return (<>
+              <h1>Books!</h1>
+              <Search searchBooks={this.searchBooks}/>
+              <section className="found-book-cards" alt="found-book-cards">
+                { this.state.foundBooks ? 
+                  this.state.foundBooks.map(foundBook => {
+                    return (
+                      <>
+                        <h1>{foundBook.title}</h1><h3>{foundBook.author}</h3><h3>Ranking: {foundBook.rank}</h3><img className="Book-card-image" alt="Book cover" src={foundBook.book_image} /> 
+                      </>
+                    )
+                  }) : 
+                  <h1>Search For Book by Title or Author</h1>
+                }
+              </section>
+              {this.createBookLists()}
+            </>)
+          }}
+          />
+          <Route exact path='/:bookId' render={({ match }) => {
+            const bookClicked = books.find((book) => book.primary_isbn10 == parseInt(match.params.bookId))
+            return <BookInfo book={bookClicked} /> }}
+          />
+          <Route exact path='/favorites' render={() =>  {
+            return <ReadingList readingList={readingList} /> 
+          }
+          } />
       </div>
     );
   }
 }
 
-export const mapStateToProps = ({ books, lists }) => ({
+export const mapStateToProps = ({ books, readingList, lists }) => ({
   books,
+  readingList,
   lists
 })
 

--- a/src/Components/App/App.test.js
+++ b/src/Components/App/App.test.js
@@ -4,7 +4,7 @@ import App from './App';
 import { screen, render, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { MemoryRouter } from 'react-router-dom';
-import { fetchAllBooks } from '../../API'
+import { fetchBooks } from '../../API'
 import { Provider } from 'react-redux';
 // import thunk from 'redux-thunk';
 // // const middlewares = [thunk];
@@ -41,7 +41,7 @@ describe('App Component', () => {
       }
     ]
 
-    fetchAllBooks.mockResolvedValue(fetchedBooks);
+    fetchBooks.mockResolvedValue(fetchedBooks);
 
     const store = mockStore({
       books: fetchedBooks

--- a/src/Components/Book/Book.test.js
+++ b/src/Components/Book/Book.test.js
@@ -27,14 +27,14 @@ describe('Book Component', () => {
     )
 
     const bookRank = screen.getByText("1", { exact: false })
-    // const bookIsbn = screen.getByText("href=/1250145236", {exact: false})
+    const bookIsbn = screen.getByRole("link", "href=/1250145236")
     const bookTitle = screen.getByText("ALL THE DEVILS ARE HERE")
     const bookImg = screen.getByAltText("ALL THE DEVILS ARE HERE", { exact: false })
-    const bookAuthor = screen.getByText("Louise Penny")
-    const addBookButton = screen.getByRole("button", {name: "Reading List"})
+    const bookAuthor = screen.getByText("Louise Penny", { exact: false })
+    const addBookButton = screen.getByRole("button", {name: "Read"})
 
     expect(bookRank).toBeInTheDocument();
-    // expect(bookIsbn).toBeInTheDocument();
+    expect(bookIsbn).toBeInTheDocument();
     expect(bookTitle).toBeInTheDocument();
     expect(bookImg).toBeInTheDocument();
     expect(bookAuthor).toBeInTheDocument();
@@ -42,6 +42,7 @@ describe('Book Component', () => {
   })
 
   it('Reading List button should be able to fire', () => {
+    const mockAddBook = jest.fn()
     const book1 = {
       rank: 1 ,
       primary_isbn10: "1250145236",
@@ -54,12 +55,14 @@ describe('Book Component', () => {
     render(
       <Provider store={store}>
         <MemoryRouter>
-          <Book book={book1}/>
+          <Book book={book1} addBook={mockAddBook}/>
         </MemoryRouter>
       </Provider>
     )
     
-    const addBookButton = screen.getByRole("button", {name: "Reading List"})
+    const addBookButton = screen.getByRole("button", {name: "Read"})
     fireEvent.click(addBookButton)
+
+    expect(mockAddBook).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/Components/BookInfo/BookInfo.test.js
+++ b/src/Components/BookInfo/BookInfo.test.js
@@ -27,7 +27,7 @@ describe('Book Info Component', () => {
     const title = screen.getByRole('heading', { name: 'WHERE THE CRAWDADS SING' });
     const author = screen.getByRole('heading', { name: 'Delia Owens' })
     const description = screen.getByText('In a quiet town...')
-    const readButton = screen.getByRole('button', { name: 'Add to Reading List' })
+    const readButton = screen.getByRole('button', { name: 'Read' })
     const purchaseButton = screen.getByRole('button', { name: 'Purchase' })
 
     expect(image).toBeInTheDocument();

--- a/src/Components/Books/Books.js
+++ b/src/Components/Books/Books.js
@@ -2,8 +2,7 @@ import React, { Component } from 'react'
 import './Books.css'
 import { fetchBooks } from '../../API'
 import Book from '../Book/Book'
-import ReadingList from '../ReadingList/ReadingList'
-import Search from '../Search/Search'
+
 import BookInfo from '../BookInfo/BookInfo'
 import { Route, Switch } from 'react-router-dom';
 import { connect } from 'react-redux'
@@ -48,10 +47,10 @@ class Books extends Component {
   }
 
   handleClick = (event) => {
-    const { addFavorite } = this.props;
+    const { addFavorite, readingList, books } = this.props;
     const id = event.target.id;
-    const foundBook = this.props.books.find(book => book.primary_isbn10 === id);
-    const isOnList = this.props.readingList.includes(foundBook)
+    const foundBook = books.find(book => book.primary_isbn10 === id);
+    const isOnList = readingList.includes(foundBook)
 
     if (!isOnList) {
       addFavorite(foundBook) 
@@ -61,62 +60,25 @@ class Books extends Component {
     }
   }
 
-  searchBooks = (search) => {
-    let findBooks = this.props.books.filter(book => {
-      if (book.title.includes(search) || book.author.includes(search)) {
-        this.setState({ foundBooks: [book] })
-      }
-    })
-    console.log(this.state.foundBooks)
-    return findBooks;
-  }
-
   render() {
-    const { books, readingList } = this.props
+    const { books } = this.props
     let bookCards = this.displayBooks()
     console.log(bookCards)
     return (
-      <Switch>
-        <Route exact path='/favorites' render={() =>
-          <ReadingList toReadList={readingList} /> } 
-        />
-        <Route exact path='/'render= {() => {
-          return (
-            <section>
-              {/* <h1>Books!</h1>
-              <Search searchBooks={this.searchBooks}/>
-              <section className="found-book-cards" alt="found-book-cards">
-                { this.state.foundBooks ? 
-                  this.state.foundBooks.map(foundBook => {
-                    return (
-                      <>
-                        <h1>{foundBook.title}</h1><h3>{foundBook.author}</h3><h3>Ranking: {foundBook.rank}</h3><img className="Book-card-image" alt="Book cover" src={foundBook.book_image} /> 
-                      </>
-                    )
-                  }) : 
-                  <h1>Search For Book by Title or Author</h1>
-                }
-              </section> */}
-              <div className="books-list">
-                <h3 className="books-list-name">{this.props.id}</h3>
-                <div className="books-container">{books && bookCards}</div>
-              </div>
-            </section>
-          )
-        }} />
-        <Route exact path='/:bookId' render={({ match }) => {
-          const bookClicked = books.find((book) => book.primary_isbn10 == parseInt(match.params.bookId))
-          return <BookInfo book={bookClicked} />
-        }} />
-      </Switch>
+      <section>
+        <div className="books-list">
+          <h3 className="books-list-name">{this.props.id}</h3>
+          <div className="books-container">{books && bookCards}</div>
+        </div>
+      </section>
     )
   }
 }
 
-export const mapStateToProps = ({ books, readingList, lists }) => ({
+export const mapStateToProps = ({ books, lists, readingList }) => ({
   books,
-  readingList,
-  lists
+  lists,
+  readingList
 })
 
 export const mapDispatchToProps = dispatch => (

--- a/src/Components/Books/Books.js
+++ b/src/Components/Books/Books.js
@@ -11,17 +11,17 @@ import { setBooks, addFavorite } from '../../actions';
 import { bindActionCreators } from 'redux';
 
 class Books extends Component {
-  constructor() {
-    super()
+  constructor(props) {
+    super(props)
     this.state = {
       foundBooks: [],
     }
   }
 
   async componentDidMount() {
-    const { setBooks } = this.props;
+    const { setBooks, list } = this.props;
     try {
-      const books = await fetchBooks('hardcover-fiction')
+      const books = await fetchBooks(list)
       setBooks(books.results.books)
     }
     catch ({ message }) {
@@ -97,7 +97,7 @@ class Books extends Component {
                 }
               </section>
               <div className="books-list">
-                <h3 className="books-list-name">**Insert List Name**</h3>
+                <h3 className="books-list-name">{this.props.id}</h3>
                 <div className="books-container">{books && bookCards}</div>
               </div>
             </section>

--- a/src/Components/Books/Books.js
+++ b/src/Components/Books/Books.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import './Books.css'
-import { fetchAllBooks } from '../../API'
+import { fetchBooks } from '../../API'
 import Book from '../Book/Book'
 import ReadingList from '../ReadingList/ReadingList'
 import Search from '../Search/Search'
@@ -21,7 +21,7 @@ class Books extends Component {
   async componentDidMount() {
     const { setBooks } = this.props;
     try {
-      const books = await fetchAllBooks()
+      const books = await fetchBooks('hardcover-fiction')
       setBooks(books.results.books)
     }
     catch ({ message }) {

--- a/src/Components/Books/Books.js
+++ b/src/Components/Books/Books.js
@@ -7,7 +7,7 @@ import Search from '../Search/Search'
 import BookInfo from '../BookInfo/BookInfo'
 import { Route, Switch } from 'react-router-dom';
 import { connect } from 'react-redux'
-import { setBooks, addFavorite } from '../../actions';
+import { setBooks, addFavorite, setList } from '../../actions';
 import { bindActionCreators } from 'redux';
 
 class Books extends Component {
@@ -19,10 +19,11 @@ class Books extends Component {
   }
 
   async componentDidMount() {
-    const { setBooks, list } = this.props;
+    const { setBooks, setList, list } = this.props;
     try {
       const books = await fetchBooks(list)
-      setBooks(books.results.books)
+      await setBooks(books.results.books)
+      await setList(list, books.results.books.map(book => book.primary_isbn10))
     }
     catch ({ message }) {
       alert(message);
@@ -57,7 +58,14 @@ class Books extends Component {
 
   displayBooks() {
     return this.props.books.map(book => {
+      const listName = this.props.list
+      const listIds = this.props.lists[listName]
+      console.log(listIds)
       return <Book book={book} addBook={this.handleClick} />
+
+      // if(this.props.lists[this.props.list].includes(book.primary_isbn10)) {
+      //   return <Book book={book} addBook={this.handleClick} />
+      // }
     })
   }
 
@@ -82,7 +90,7 @@ class Books extends Component {
         <Route exact path='/'render= {() => {
           return (
             <section>
-              <h1>Books!</h1>
+              {/* <h1>Books!</h1>
               <Search searchBooks={this.searchBooks}/>
               <section className="found-book-cards" alt="found-book-cards">
                 { this.state.foundBooks ? 
@@ -95,7 +103,7 @@ class Books extends Component {
                   }) : 
                   <h1>Search For Book by Title or Author</h1>
                 }
-              </section>
+              </section> */}
               <div className="books-list">
                 <h3 className="books-list-name">{this.props.id}</h3>
                 <div className="books-container">{books && bookCards}</div>
@@ -112,15 +120,17 @@ class Books extends Component {
   }
 }
 
-export const mapStateToProps = ({ books, readingList }) => ({
+export const mapStateToProps = ({ books, readingList, lists }) => ({
   books,
-  readingList
+  readingList,
+  lists
 })
 
 export const mapDispatchToProps = dispatch => (
   bindActionCreators({
     setBooks,
-    addFavorite
+    addFavorite,
+    setList
   }, dispatch)
 )
 

--- a/src/Components/Books/Books.js
+++ b/src/Components/Books/Books.js
@@ -14,20 +14,25 @@ class Books extends Component {
   constructor(props) {
     super(props)
     this.state = {
+      books: [],
       foundBooks: [],
     }
   }
 
-  async componentDidMount() {
-    const { setBooks, setList, list } = this.props;
-    try {
-      const books = await fetchBooks(list)
-      await setBooks(books.results.books)
-      await setList(list, books.results.books.map(book => book.primary_isbn10))
+  componentDidMount() {
+    this.setState({ books: this.props.filteredBooks })
+  }
+
+  componentDidUpdate(prevProps) {
+    if(this.props.filteredBooks !== prevProps.filteredBooks) {
+      this.setState({ books: this.props.filteredBooks })
     }
-    catch ({ message }) {
-      alert(message);
-    }
+  }
+
+  displayBooks() {
+    return this.state.books.map(book => {
+      return <Book book={book} addBook={this.handleClick}/>
+    })
   }
 
   changeButtonStyling(id) {
@@ -56,19 +61,6 @@ class Books extends Component {
     }
   }
 
-  displayBooks() {
-    return this.props.books.map(book => {
-      const listName = this.props.list
-      const listIds = this.props.lists[listName]
-      console.log(listIds)
-      return <Book book={book} addBook={this.handleClick} />
-
-      // if(this.props.lists[this.props.list].includes(book.primary_isbn10)) {
-      //   return <Book book={book} addBook={this.handleClick} />
-      // }
-    })
-  }
-
   searchBooks = (search) => {
     let findBooks = this.props.books.filter(book => {
       if (book.title.includes(search) || book.author.includes(search)) {
@@ -82,6 +74,7 @@ class Books extends Component {
   render() {
     const { books, readingList } = this.props
     let bookCards = this.displayBooks()
+    console.log(bookCards)
     return (
       <Switch>
         <Route exact path='/favorites' render={() =>

--- a/src/Components/Books/Books.test.js
+++ b/src/Components/Books/Books.test.js
@@ -5,7 +5,6 @@ import { MemoryRouter } from 'react-router-dom';
 import { createStore } from 'redux';
 import { rootReducer } from '../../reducers/index';
 import { Provider } from 'react-redux'
-import { fetchAllBooks } from '../../API';
 jest.mock('../../API');
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
@@ -29,12 +28,9 @@ describe('Books Component', () => {
   })
 
   it('Should render book cards', async () => {
-
-    fetchAllBooks.mockResolvedValue(fetchedBooks);
-
     // const store = createStore(rootReducer);
     const store = mockStore({
-      books:fetchedBooks
+      books: fetchedBooks
     }
 
     );

--- a/src/Components/Search/Search.test.js
+++ b/src/Components/Search/Search.test.js
@@ -4,11 +4,11 @@ import { screen, render, waitFor, fireEvent } from '@testing-library/react'
 import Search from './Search.js'
 jest.mock('../../API');
 
-describe('Search Componey', () => {
+describe('Search Component', () => {
   it('should render a search bar and button', () => {
     render(<Search />);
 
-    const searchInput = screen.getByPlaceholderText('search')
+    const searchInput = screen.getByPlaceholderText('search for title or author')
     const submitButton = screen.getByRole('button', {name: 'Search'})
 
     expect(searchInput).toBeInTheDocument()
@@ -19,7 +19,7 @@ describe('Search Componey', () => {
     const searchBooks = jest.fn();
     render(<Search searchBooks={searchBooks} />)
 
-    const searchInput = screen.getByPlaceholderText('search')
+    const searchInput = screen.getByPlaceholderText('search for title or author')
     const submitButton = screen.getByRole('button', {name: 'Search'})
 
     expect(searchInput).toBeInTheDocument()

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -3,6 +3,12 @@ export const setBooks = (books) => ({
     books
 });
 
+export const setList = (listName, idNumbers) => ({
+  type: 'SET_LIST',
+  listName,
+  idNumbers
+})
+
 export const addFavorite = (book) => ({
   type: 'ADD_TO_READING_LIST',
   book

--- a/src/reducers/Books.js
+++ b/src/reducers/Books.js
@@ -1,7 +1,8 @@
 export const books = (state = [], action) => {
     switch(action.type) {
         case 'SET_BOOKS':
-            return action.books
+            const newState = [...state, ...action.books]
+            return newState
         default: 
             return state
     }

--- a/src/reducers/Lists.js
+++ b/src/reducers/Lists.js
@@ -1,4 +1,12 @@
-export const lists = (state = {}, action) => {
+const initState = {
+    'celebrities': [],
+    'food-and-fitness': [],
+    'hardcover-fiction': [],
+    'health': [],
+    'games-and-activities': [],
+}
+
+export const lists = (state = initState, action) => {
     switch(action.type) {
         case 'SET_LIST':
             state[action.listName] = action.idNumbers;

--- a/src/reducers/Lists.js
+++ b/src/reducers/Lists.js
@@ -1,7 +1,6 @@
 export const lists = (state = {}, action) => {
     switch(action.type) {
         case 'SET_LIST':
-            console.log(action)
             state[action.listName] = action.idNumbers;
             return state
         default:

--- a/src/reducers/Lists.js
+++ b/src/reducers/Lists.js
@@ -1,0 +1,10 @@
+export const lists = (state = {}, action) => {
+    switch(action.type) {
+        case 'SET_LIST':
+            console.log(action)
+            state[action.listName] = action.idNumbers;
+            return state
+        default:
+            return state
+    }
+}

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,8 +1,10 @@
 import { readingList } from './ReadingList'
 import { books } from './Books'
+import { lists } from './Lists'
 import { combineReducers } from 'redux'
 
 export const rootReducer = combineReducers({ 
     books,
-    readingList
+    readingList,
+    lists
 })


### PR DESCRIPTION
#### What's this PR do?
- Refactors our store to have books & list structure.
- Adds extra lists into our reducer 
- Adds state to `App` to eventually allow users to toggle which books are displayed
- Moves `Search` to `App`
- Adds `Route` to `App` to render appropriate content
- Refactors tests that were failing because of these changes

Type of change made:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Styling- no new features

#### Where should the reviewer start?
- Check out the App and Books file, this is where the bulk of the re-structuring happened! Then look at the other files.

#### Why is this change required? What problem does it solve?
- In order to get more lists, and not store our books in two places, we came up with this new data structure for store. These changes implement that data structure.

#### Were there any challenges that arose while implementing this feature? If so, how were they addressed?
- It was difficult to get the filtered books to show up in their respective links! With some strategic debugging and a help from Khalid, I'm glad we got through it.

#### What are the relevant tickets?
- Close #32 

#### Screenshots (if appropriate)
- ![Screen Shot 2020-09-14 at 4 49 15 PM](https://user-images.githubusercontent.com/62263439/93145687-3e668200-f6aa-11ea-8a23-120c97a21bfb.png)

#### Questions:
- We still have that slight bug where one list won't load. How can we integrate Khalid's feedback from the thread to solve this?
