### PR TITLE
Add code to app to prevent duplicate books from being rendered if it'…

### DIFF
--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -33,9 +33,13 @@ class App extends Component {
     try {
       allListUrls.map(async url => {
         const response = await fetchBooks(url);
-        setBooks(response.results.books);
         const books = response.results.books;
-        return setList(url, books.map(book => book.primary_isbn10));
+        const newBooks = books.map(book => {
+          book.listName = url
+          return book
+        })
+        setBooks(newBooks);
+        return setList(url, newBooks.map(book => book.primary_isbn10));
       })
     }
     catch ({ message }) {
@@ -45,7 +49,11 @@ class App extends Component {
 
   filterBooks = (listName) => {
     const listOfIds = this.props.lists[listName]
-    const filteredBooks = this.props.books.filter(book => listOfIds.includes(book.primary_isbn10))
+    const filteredBooks = this.props.books.filter(book => {
+      if(listOfIds.includes(book.primary_isbn10) && book.listName === listName) {
+        return book
+      }
+    })
     return filteredBooks;
   }
 


### PR DESCRIPTION
…s on 2 lists

#### What's this PR do?
- Fixes a small bug wherein the same book renders twice on a list if it happens to be on two separate lists. We did this by adding a new property to each book that has it's url name, and then adding a condition to `filterBooks` to ensure the book is on the appropriate list.

Type of change made:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Styling- no new features

#### Where should the reviewer start?
- `App`

#### Why is this change required? What problem does it solve?
- To prevent duplicate books & out of order lists!
